### PR TITLE
Features - Add MuJoCo validation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "redhat.vscode-xml"
+    ]
+}

--- a/playground/open_duck_mini_v2/xmls/open_duck_mini_v2.xml
+++ b/playground/open_duck_mini_v2/xmls/open_duck_mini_v2.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <!-- Generated using onshape-to-robot -->
 <!-- Onshape document_id: 64074dfcfa379b37d8a47762 -->
-<mujoco model="open_duck_mini_v2">
+<mujoco 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/julien-blanchon/mujoco-schema/refs/heads/main/mujoco_schema.xsd" 
+  model="open_duck_mini_v2">
 
   <option iterations="1" ls_iterations="5">
     <flag eulerdamp="disable"/>

--- a/playground/open_duck_mini_v2/xmls/open_duck_mini_v2_backlash.xml
+++ b/playground/open_duck_mini_v2/xmls/open_duck_mini_v2_backlash.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <!-- Generated using onshape-to-robot -->
 <!-- Onshape document_id: 64074dfcfa379b37d8a47762 -->
-<mujoco model="open_duck_mini_v2">
+<mujoco 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/julien-blanchon/mujoco-schema/refs/heads/main/mujoco_schema.xsd"
+  model="open_duck_mini_v2">
 
   <option iterations="1" ls_iterations="5">
     <flag eulerdamp="disable"/>

--- a/playground/open_duck_mini_v2/xmls/scene_flat_terrain.xml
+++ b/playground/open_duck_mini_v2/xmls/scene_flat_terrain.xml
@@ -1,4 +1,8 @@
-<mujoco model="scene">
+<mujoco
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/julien-blanchon/mujoco-schema/refs/heads/main/mujoco_schema.xsd" 
+    model="scene"
+    >
     <include file="open_duck_mini_v2.xml"/>
 
     <visual>

--- a/playground/open_duck_mini_v2/xmls/scene_flat_terrain_backlash.xml
+++ b/playground/open_duck_mini_v2/xmls/scene_flat_terrain_backlash.xml
@@ -1,4 +1,7 @@
-<mujoco model="scene">
+<mujoco 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/julien-blanchon/mujoco-schema/refs/heads/main/mujoco_schema.xsd" 
+    model="scene">
     <include file="open_duck_mini_v2_backlash.xml"/>
 
     <visual>

--- a/playground/open_duck_mini_v2/xmls/scene_rough_terrain_backlash.xml
+++ b/playground/open_duck_mini_v2/xmls/scene_rough_terrain_backlash.xml
@@ -1,4 +1,7 @@
-<mujoco model="Open Duck Mini V2 rough terrain scene">
+<mujoco 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/julien-blanchon/mujoco-schema/refs/heads/main/mujoco_schema.xsd" 
+  model="Open Duck Mini V2 rough terrain scene">
   <!-- <include file="open_duck_mini_v2_no_head.xml"/> -->
   <include file="open_duck_mini_v2_backlash.xml"/>
 


### PR DESCRIPTION
Small quality of life improvement, add schema validation to the mujoco XML files.

For vscode [redhat.vscode-xml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml) extension need to be install