### PR TITLE
Removed accelerometer bias

### DIFF
--- a/playground/open_duck_mini_v2/joystick.py
+++ b/playground/open_duck_mini_v2/joystick.py
@@ -498,8 +498,6 @@ class Joystick(open_duck_mini_v2_base.OpenDuckMiniV2Env):
         )
 
         accelerometer = self.get_accelerometer(data)
-        # accelerometer[0] += 1.3 # TODO testing
-        accelerometer.at[0].set(accelerometer[0] + 1.3)
 
         info["rng"], noise_rng = jax.random.split(info["rng"])
         noisy_accelerometer = (

--- a/playground/open_duck_mini_v2/mujoco_infer.py
+++ b/playground/open_duck_mini_v2/mujoco_infer.py
@@ -71,7 +71,6 @@ class MjInfer(MJInferBase):
     ):
         gyro = self.get_gyro(data)
         accelerometer = self.get_accelerometer(data)
-        accelerometer[0] += 1.3
 
         joint_angles = self.get_actuator_joints_qpos(data.qpos)
         joint_vel = self.get_actuator_joints_qvel(data.qvel)


### PR DESCRIPTION
Removed `accelerometer[0] += 1.3` from `mujoco_infer.py` to match what your policy was actually trained with.

## Short Summary

**JAX Bug (`joystick.py`):**
```python
accelerometer.at[0].set(accelerometer[0] + 1.3)  # Returns new array, but result is discarded
```
JAX arrays are **immutable** — `.at[].set()` creates and returns a *new* array. Without assigning it back (`accelerometer = ...`), the original array is unchanged. The +1.3 offset was never applied during training.

**NumPy Code (`mujoco_infer.py`):**
```python
accelerometer[0] += 1.3  # Works — NumPy arrays are mutable
```
NumPy arrays are **mutable** — in-place modification works. The +1.3 offset IS applied during inference.

**Result:** Policy trained with `accelerometer[0] = X`, but inference sees `accelerometer[0] = X + 1.3`. This observation mismatch can degrade policy performance.